### PR TITLE
Preventing photosensitive seizures during `make up`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 up:
 	./generate.sh && \
-	COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose build --parallel && \
+	COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose build --parallel --progress=plain && \
 	docker-compose up -d
 
 down:


### PR DESCRIPTION
The flashing console was trying to kill when running `make up`, this is a fix to it.