### PR TITLE
Fixed issue where search button would not hide at the same time as modal

### DIFF
--- a/webapp/src/Header.js
+++ b/webapp/src/Header.js
@@ -45,7 +45,7 @@ function Search() {
             <FontAwesomeIcon className="mr-1 text-gray-400" icon={faSearch} />
           }
         />
-              <div id="hidden-search-modal" className="absolute text-black bg-white w-full max-w-sm p-5 space-y-3 invisible">
+              <div id="hidden-search-modal" className="absolute hidden text-black bg-white w-full max-w-sm p-5 space-y-3">
                   <h1 className="text-black text-base" >SEARCH OPTIONS</h1>
                   <b className="text-black text-base" >Order by: </b>
                   <select name="category" className="bg-white" id="category">
@@ -203,11 +203,11 @@ function UserNav(props) {
 }
 
 function showModal(){
-    document.getElementById('hidden-search-modal').style.setProperty("visibility", 'visible', 'important');
+    document.getElementById('hidden-search-modal').style.setProperty('display', 'block', 'important');
 }
 
 function hideModal(){
-    document.getElementById('hidden-search-modal').style.setProperty("visibility", 'hidden', 'important');
+    document.getElementById('hidden-search-modal').style.setProperty('display', 'none', 'important');
 }
 
 function Header(props) {


### PR DESCRIPTION
Previously in chrome when I would hover away from the search modal, the modal would disappear first and the search button would disappear with a delay. This fixes this issue