### PR TITLE
chore: vscode setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# vscode files
+*.code-workspace
+
 youtube-dl*
 packer/vpn_conf*
 data*

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "golang.go"
+  ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
   "recommendations": [
-    "golang.go"
+    "golang.go",
+    "zxh404.vscode-proto3"
   ]
 }

--- a/.vscode/horahora.code-workspace.example
+++ b/.vscode/horahora.code-workspace.example
@@ -1,0 +1,59 @@
+{
+	"folders": [
+		{
+			"name": "horahora",
+			"path": "."
+		},
+		{
+			"name": "front_api",
+			"path": "front_api"
+		},
+		{
+			"name": "backup_service",
+			"path": "backup_service"
+		},
+		{
+			"name": "scheduler",
+			"path": "scheduler"
+		},
+		{
+			"name": "stomp_proxy",
+			"path": "stomp_proxy"
+		},
+		{
+			"name": "tests",
+			"path": "tests"
+		},
+		{
+			"name": "user_service",
+			"path": "user_service"
+		},
+		{
+			"name": "video_service",
+			"path": "video_service"
+		},
+		{
+			"name": "webapp",
+			"path": "webapp"
+		}
+	],
+	"settings": {
+		"files.exclude": {
+			"**/.git": true,
+			"**/.svn": true,
+			"**/.hg": true,
+			"**/CVS": true,
+			"**/.DS_Store": true,
+			"**/Thumbs.db": true,
+			"**/node_modules": true,
+			"front_api": true,
+			"backup_service": true,
+			"scheduler": true,
+			"stomp_proxy": true,
+			"tests": true,
+			"user_service": true,
+			"video_service": true,
+			"webapp": true
+		}
+	}
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+  "gopls": {
+    "ui.semanticTokens": true,
+  },
+  "[json]": {
+    "editor.tabSize": 2
+  },
+  "[jsonc]": {
+    "editor.tabSize": 2
+  }
+}

--- a/horahora.code-workspace
+++ b/horahora.code-workspace
@@ -1,9 +1,0 @@
-{
-	"folders": [
-		{
-			"name": "horahora",
-			"path": "."
-		}
-	],
-	"settings": {}
-}

--- a/webapp/.vscode/extensions.json
+++ b/webapp/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "dbaeumer.vscode-eslint"
+    ]
+}


### PR DESCRIPTION
Golang extension for VSCode requires each module folder to be a root in a multi-root workspace, but enforcing roots on the whole workspace is too opinionated.
So instead there is an example workspace file which can be used as a baseline.