### PR TITLE
fix(webapp): account-related fixes

### DIFF
--- a/webapp/src/api/account.ts
+++ b/webapp/src/api/account.ts
@@ -3,7 +3,7 @@ import { FetchError, PublicAPIURL } from "./types";
 import { type IAccountClient } from "#codegen/schema/001_interfaces";
 
 export async function fetchAccountInfo() {
-  const url = new PublicAPIURL("/currentuserprofile");
+  const url = new PublicAPIURL("/currentuserprofile/");
   const response = await fetch(url, {
     method: "GET",
   });

--- a/webapp/src/components/layout/account-nav.tsx
+++ b/webapp/src/components/layout/account-nav.tsx
@@ -24,12 +24,12 @@ import styles from "./account-nav.module.scss";
 
 export function AccountNavigation() {
   const [isOpen, switchOpen] = useState(false);
-  const { account, isRegistered, isAdmin, logout } = useAccount();
+  const { account, isInProgress, isRegistered, isAdmin, logout } = useAccount();
 
   const className = clsx(
     styles.block,
     isOpen && styles.block_open,
-    !account && styles.block_loading
+    isInProgress && styles.block_loading
   );
 
   return (

--- a/webapp/src/hooks/account.tsx
+++ b/webapp/src/hooks/account.tsx
@@ -75,7 +75,7 @@ export function AccountProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     (async () => {
       try {
-        if (isRegistered()) {
+        if (!isRegistered()) {
           return;
         }
 

--- a/webapp/src/hooks/account.tsx
+++ b/webapp/src/hooks/account.tsx
@@ -20,6 +20,7 @@ import { UserRank } from "#api/types";
 
 interface IAccountContext {
   account?: IAccount;
+  isInProgress: boolean;
   register: (...args: Parameters<typeof registerAccount>) => Promise<void>;
   login: (...args: Parameters<typeof loginAccount>) => Promise<void>;
   logout: (...args: Parameters<typeof logoutAccount>) => Promise<void>;
@@ -34,6 +35,7 @@ interface IUseAccount extends IAccountContext {
 // has to have the same type as the context
 // but these functions can't operate outside of the context component.
 const defaultContext: IAccountContext = {
+  isInProgress: false,
   register: async () => {},
   login: async () => {},
   logout: async () => {},
@@ -43,6 +45,7 @@ const AccountContext = createContext<IAccountContext>(defaultContext);
 
 export function AccountProvider({ children }: { children: ReactNode }) {
   const [account, changeAccount] = useState<IAccount | undefined>(undefined);
+  const [isInProgress, switchProgress] = useState(true);
 
   // dunno if `useCallback()` is needed
   // but react can struggle with referential equality of functions
@@ -71,29 +74,33 @@ export function AccountProvider({ children }: { children: ReactNode }) {
   // initialize the context
   useEffect(() => {
     (async () => {
-      if (isRegistered()) {
-        return;
-      }
-
-      const accountData = getAccount();
-
-      if (accountData) {
-        changeAccount(accountData);
-        return;
-      }
-
       try {
+        if (isRegistered()) {
+          return;
+        }
+
+        const accountData = getAccount();
+
+        if (accountData) {
+          changeAccount(accountData);
+          return;
+        }
+
         const remoteAccountData = await fetchAccountInfo();
         changeAccount(remoteAccountData);
       } catch (error) {
         console.log(error);
         return;
+      } finally {
+        switchProgress(false);
       }
     })();
   }, []);
 
   return (
-    <AccountContext.Provider value={{ account, register, login, logout }}>
+    <AccountContext.Provider
+      value={{ account, isInProgress, register, login, logout }}
+    >
       {children}
     </AccountContext.Provider>
   );

--- a/webapp/src/lib/account/auth.ts
+++ b/webapp/src/lib/account/auth.ts
@@ -46,6 +46,8 @@ export async function loginAccount(
 
   await fetchLoginAccount(formParams);
 
+  setLocalStoreItem<boolean>(LOCAL_STORAGE.IS_REGISTERED, true);
+
   const account = await fetchAccountInfo();
 
   setLocalStoreItem<IAccountClient>(LOCAL_STORAGE.ACCOUNT, account);


### PR DESCRIPTION
- account nav doesn't get stuck in loading state for unregistered users
- account hook doesn't crash on failed initialization
- fixed account info fetch url 
    Why does it even end with a slash in the first place?
    It's not a resource and it doesn't return a collection of links. 