### PR TITLE
fix(webapp): codegen

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -14,6 +14,7 @@
         "@fortawesome/react-fontawesome": "^0.1.18",
         "@stomp/stompjs": "^6.1.2",
         "ajv": "^8.11.0",
+        "ajv-formats": "^2.1.1",
         "antd": "^4.16.2",
         "axios": "^0.21.2",
         "clsx": "^1.1.1",
@@ -1143,6 +1144,22 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-regex": {
@@ -7034,6 +7051,14 @@
         "json-schema-traverse": "^1.0.0",
         "require-from-string": "^2.0.2",
         "uri-js": "^4.2.2"
+      }
+    },
+    "ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "requires": {
+        "ajv": "^8.0.0"
       }
     },
     "ansi-regex": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -17,6 +17,7 @@
     "@fortawesome/react-fontawesome": "^0.1.18",
     "@stomp/stompjs": "^6.1.2",
     "ajv": "^8.11.0",
+    "ajv-formats": "^2.1.1",
     "antd": "^4.16.2",
     "axios": "^0.21.2",
     "clsx": "^1.1.1",

--- a/webapp/src/lib/json-schema/validation.ts
+++ b/webapp/src/lib/json-schema/validation.ts
@@ -46,14 +46,19 @@ export function createValidator<SchemaInterface>(
   schema: IJSONSchema,
   ajv: ReturnType<typeof createAJV>
 ) {
-  const validate: ValidateFunction<SchemaInterface> | undefined =
-    ajv.getSchema<SchemaInterface>(schema.$id);
-
-  if (!validate) {
-    throw new Error(`JSON Schema with "$id" "${schema.$id}" doesn't exist.`);
-  }
+  let validate: ValidateFunction<SchemaInterface> | undefined = undefined;
 
   return (inputJSON: unknown): inputJSON is SchemaInterface => {
+    if (!validate) {
+      validate = ajv.getSchema<SchemaInterface>(schema.$id);
+
+      if (!validate) {
+        throw new Error(
+          `JSON Schema with "$id" "${schema.$id}" doesn't exist.`
+        );
+      }
+    }
+
     const result = validate(inputJSON);
 
     if (!result) {

--- a/webapp/src/lib/json-schema/validation.ts
+++ b/webapp/src/lib/json-schema/validation.ts
@@ -62,8 +62,8 @@ export function createValidator<SchemaInterface>(
     const result = validate(inputJSON);
 
     if (!result) {
-      // `errors` key is always an array when validation is failed
-      const errors = [...(validate.errors! as DefinedError[])];
+      // @ts-expect-error `errors` key is always an array when validation is failed
+      const errors: DefinedError[] = [...validate.errors];
       throw new ValidationError(errors, schema.$id);
     }
 

--- a/webapp/src/lib/json-schema/validation.ts
+++ b/webapp/src/lib/json-schema/validation.ts
@@ -1,5 +1,6 @@
 import Ajv, { type ValidateFunction, type DefinedError } from "ajv";
 import { type JSONSchema7 } from "json-schema";
+import addFormats from "ajv-formats";
 
 import { multilineString } from "#lib/strings";
 
@@ -32,9 +33,13 @@ export class ValidationError extends Error {
 }
 
 export function createAJV(schemaMap: ISchemaMap) {
-  return new Ajv({
+  const ajv = new Ajv({
     schemas: Object.values(schemaMap),
   });
+
+  addFormats(ajv);
+
+  return ajv;
 }
 
 export function createValidator<SchemaInterface>(

--- a/webapp/src/server/codegen/lib.ts
+++ b/webapp/src/server/codegen/lib.ts
@@ -60,30 +60,26 @@ export async function runCodegen() {
 
         const resultInfo = {
           module: finalResult,
-          index: indexContent
+          index: indexContent,
         };
 
         Object.entries(resultInfo).forEach(([key, code]) => {
           try {
-            const formattedCode = prettier.format(code);
+            const formattedCode = prettier.format(code, {
+              parser: "typescript",
+            });
             // @ts-expect-error dict mutation
-            resultInfo[key] = formattedCode
+            resultInfo[key] = formattedCode;
           } catch (error) {
             console.warn(
               `Failed to format the ${key} at "${resultPath}"`,
               "Continue unformatted"
             );
           }
-        })
+        });
 
-        await fs.writeFile(
-          resultPath,
-          resultInfo.module
-        );
-        await fs.writeFile(
-          indexPath,
-          resultInfo.index
-        );
+        await fs.writeFile(resultPath, resultInfo.module);
+        await fs.writeFile(indexPath, resultInfo.index);
 
         codegenDirs.push(path.relative(codegenPath, entryPath.dir));
 


### PR DESCRIPTION
- `prettier` formats the results without crashing
- deferred validator initialization
- string `format` keyword support